### PR TITLE
Setup should now work

### DIFF
--- a/dkb_robo/__init__.py
+++ b/dkb_robo/__init__.py
@@ -1,5 +1,5 @@
 """ init """
-from .dkb_robo import DKBRobo
+from .version import __version__ as our_version
 
-__version__ = '0.10.2'
+__version__ = our_version
 __author__ = 'GrindSa'


### PR DESCRIPTION
Before doing either pip install or python setup install failed since
you are importing the module in the __init__ file and using that init
file in the setup.py

This lead to this failure:

```
Traceback (most recent call last):                                                                                                      
  File "/home/lefteris/w/dkb-robo/setup.py", line 3, in <module>                                                                        
    from dkb_robo.version import __version__
  File "/home/lefteris/w/dkb-robo/dkb_robo/__init__.py", line 2, in <module>
    from .dkb_robo import DKBRobo                                                                                                                                                                                                                                                
  File "/home/lefteris/w/dkb-robo/dkb_robo/dkb_robo.py", line 15, in <module>                                                           
    import mechanicalsoup                                                                                                                                                                                                                                                        
ModuleNotFoundError: No module named 'mechanicalsoup'
```

Right now it will work fine, **BUT** you will need to import DKBRobo from the dkb_robo file. It's either this, or we put the version name inside setup.py. Whatever you guys prefer.