### PR TITLE
[doc] add long description to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 """ setup.py """
+from pathlib import Path
 from setuptools import setup
+
+this_directory = Path(__file__).parent
+long_description = (this_directory / 'README.md').read_text()
+
 setup(name='dkb_robo',
     version='0.20',
     description='library to access the internet banking area of "Deutsche Kreditbank" to get account information and transactions.',
+    long_description=long_description,
     url='https://github.com/grindsa/dkb-robo',
     author='grindsa',
     author_email='grindelsack@gmail.com',


### PR DESCRIPTION
Hey, i noticed that your pypa dist doesn't have a long description.  These changes will add it from your readme.  Let me know if you'd need anything else for this PR.