### PR TITLE
scan-postbox: Rename path option's env variable from PATH to DKB_DOC_PATH 

### DIFF
--- a/dkb_robo/cli.py
+++ b/dkb_robo/cli.py
@@ -205,7 +205,7 @@ def standing_orders(ctx):
     "-p",
     type=str,
     help="Path to save the documents to",
-    envvar="PATH",
+    envvar="DKB_DOC_PATH",
 )
 @click.option("--download_all", is_flag=True, show_default=True, default=False, help="Download all documents", envvar="DKB_DOWNLOAD_ALL")
 @click.option("--archive", is_flag=True, show_default=True, default=False, help="Download archive", envvar="DKB_ARCHIVE")


### PR DESCRIPTION
The "PATH" env variable is typically populated with values that lead to unfortunate results when calling this command with an explicit path parameter.