### PR TITLE
Fix to allow non-chip-tan MFAs again

### DIFF
--- a/dkb_robo/cli.py
+++ b/dkb_robo/cli.py
@@ -33,7 +33,7 @@ DATE_FORMAT_ALTERNATE = "%Y-%m-%d"
 @click.option(
     "--chip-tan",
     "-t",
-    default=False,
+    default=None,
     help='use ChipTAN for login (either "qr" or "manual")',
     type=str,
     envvar="DKB_CHIP_TAN",


### PR DESCRIPTION
Since the change of the chip-tan option from boolean to string, the chip-tan option was always considered enabled.