### PR TITLE
Fix prepend_date logic

### DIFF
--- a/dkb_robo/api.py
+++ b/dkb_robo/api.py
@@ -779,9 +779,12 @@ class Wrapper(object):
 
         rcode = 'unknown'
         if path:
-            if prepend_date and document['filename'] in documentname_list:
-                self.logger.debug('api.Wrapper._filter_postbox(): duplicate document name. Renaming %s', document['filename'])
+            if prepend_date or document['filename'] in documentname_list:
+                if document['filename'] in documentname_list:
+                    self.logger.debug('api.Wrapper._filter_postbox(): duplicate document name. Renaming %s', document['filename'])
                 document['filename'] = f'{document["date"]}_{document["filename"]}'
+                if document['filename'] in documentname_list:
+                    raise DKBRoboError(f"Duplicate document name and date: {document['filename']}")
             rcode = self._download_document(path, document)
             documentname_list.append(document['filename'])
 


### PR DESCRIPTION
The logic for non-legacy `prepend_date` as I understood from the documentation does not seem to match the code.

Code version:

* prepend the date only if the filename is duplicate AND `prepend_date` is `True`

Suggested change:

* prepend the date if the filename is duplicate OR if `prepend_date` is `True`
 
I also added an error in case the renamed document still has a conflict.