### PR TITLE
Clean up release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -13,6 +13,10 @@ jobs:
   build:
     name: Create and upload release
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ env.TAG_NAME }}
+      app_name: ${{ env.APP_NAME }}
+      should_release: ${{ env.SHOULD_RELEASE || 'false' }}
     steps:
 
       - name: "[ PREPARE ] Set up Python"
@@ -39,14 +43,23 @@ jobs:
           echo TAG_NAME=$(python3 -c "import dkb_robo; print(dkb_robo.__version__)") >> $GITHUB_ENV
           echo APP_NAME=$(echo ${{ github.repository }} | awk -F / '{print $2}') >> $GITHUB_ENV
 
+      - name: "[ PREPARE ] Check version difference"
+        run: |
+          if [ "${{ steps.dkb_robo_ver.outputs.tag }}" != "${{ env.TAG_NAME }}" ]; then
+            echo "SHOULD_RELEASE=true" >> $GITHUB_ENV
+          else
+            echo "SHOULD_RELEASE=false" >> $GITHUB_ENV
+          fi
+
       - run: |
           echo "Repo is at version ${{ steps.dkb_robo_ver.outputs.tag }}"
           echo "APP tag is ${{ env.APP_NAME }}"
           echo "Latest tag is ${{ env.TAG_NAME }}"
+          echo "should_release is ${{ env.SHOULD_RELEASE }}"
 
       - name: "[ BUILD ] Create Release"
         id: create_release
-        if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
+        if: env.SHOULD_RELEASE == 'true'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,11 +73,11 @@ jobs:
 
       - name: "[ BUILD ] Build a binary wheel and a source tarball"
         id: create_package
-        if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
+        if: env.SHOULD_RELEASE == 'true'
         run: python3 -m build
 
       - name: "[ UPLOAD ] Upload package artifacts"
-        if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        if: env.SHOULD_RELEASE == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: dist
@@ -73,24 +86,24 @@ jobs:
   upload-to-pypi:
     needs: build
     runs-on: ubuntu-latest
+    if: needs.build.outputs.should_release == 'true'
     steps:
       - name: "[ DOWNLOAD ] Download package artifacts"
         uses: actions/download-artifact@v4
-        if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
         with:
           name: dist
           path: dist
 
       - name: "[ UPLOAD ] Publish package"
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
 
   create-sbom:
-    needs: upload-to-pypi
+    needs: [build, upload-to-pypi]
     runs-on: ubuntu-latest
+    if: needs.build.outputs.should_release == 'true'
     steps:
       - name: "[ PREPARE ] Checkout code"
         uses: actions/checkout@v4

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -63,12 +63,37 @@ jobs:
         if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: python3 -m build
 
+      - name: "[ UPLOAD ] Upload package artifacts"
+        if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+  upload-to-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[ DOWNLOAD ] Download package artifacts"
+        uses: actions/download-artifact@v4
+        if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        with:
+          name: dist
+          path: dist
+
       - name: "[ UPLOAD ] Publish package"
         uses: pypa/gh-action-pypi-publish@release/v1
         if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+
+  create-sbom:
+    needs: upload-to-pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[ PREPARE ] Checkout code"
+        uses: actions/checkout@v4
 
       - name: "[ PREPARE ] Retrieve SBOM repo"
         run: |

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
 jobs:
   build:
     name: Create and upload release

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           repository: ${{ github.repository }}  # The repository to scan.
           releases-only: true  # We know that all relevant tags have a GitHub release for them.
-        id: dbv_robo_ver  # The step ID to refer to later.
+        id: dkb_robo_ver  # The step ID to refer to later.
 
       - name: "[ PREPARE ] Checkout code"
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
 
       - name: "[ BUILD ] Create Release"
         id: create_release
-        if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,18 +60,18 @@ jobs:
 
       - name: "[ BUILD ] Build a binary wheel and a source tarball"
         id: create_package
-        if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: python3 -m build
 
       - name: "[ UPLOAD ] Publish package"
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
 
       - name: "[ PREPARE ] Retrieve SBOM repo"
-        # if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        # if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: |
           git clone https://$GH_SBOM_USER:$GH_SBOM_TOKEN@github.com/$GH_SBOM_USER/sbom /tmp/sbom
         env:
@@ -79,7 +79,7 @@ jobs:
           GH_SBOM_TOKEN: ${{ secrets.GH_SBOM_TOKEN }}
 
       - name: "[ BUILD ] virtual environment"
-        # if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        # if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: |
           python3 -m venv /tmp/dkbroboenv
           source /tmp/dkbroboenv/bin/activate
@@ -89,7 +89,7 @@ jobs:
           deactivate
 
       - name: "[ BUILD ] create SBOM"
-        # if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        # if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: |
           mkdir -p /tmp/sbom/sbom/dkb-robo
           cp /tmp/requirements_freeze.txt /tmp/sbom/sbom/dkb-robo/dkb-robo_sbom.txt
@@ -98,7 +98,7 @@ jobs:
           python3 -m cyclonedx_py environment -v --pyproject pyproject.toml --mc-type library --output-reproducible --output-format json --outfile /tmp/sbom/sbom/dkb-robo/dkb-robo_sbom.json /tmp/dkbroboenv
 
       - name: "[ BUILD ] Upload SBOM"
-        # if: steps.dbv_robo_ver.outputs.tag != env.TAG_NAME
+        # if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: |
           cd /tmp/sbom
           git config --global user.email "grindelsack@gmail.com"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -71,7 +71,6 @@ jobs:
           password: ${{ secrets.PYPI_TOKEN }}
 
       - name: "[ PREPARE ] Retrieve SBOM repo"
-        # if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: |
           git clone https://$GH_SBOM_USER:$GH_SBOM_TOKEN@github.com/$GH_SBOM_USER/sbom /tmp/sbom
         env:
@@ -79,7 +78,6 @@ jobs:
           GH_SBOM_TOKEN: ${{ secrets.GH_SBOM_TOKEN }}
 
       - name: "[ BUILD ] virtual environment"
-        # if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: |
           python3 -m venv /tmp/dkbroboenv
           source /tmp/dkbroboenv/bin/activate
@@ -89,7 +87,6 @@ jobs:
           deactivate
 
       - name: "[ BUILD ] create SBOM"
-        # if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: |
           mkdir -p /tmp/sbom/sbom/dkb-robo
           cp /tmp/requirements_freeze.txt /tmp/sbom/sbom/dkb-robo/dkb-robo_sbom.txt
@@ -98,7 +95,6 @@ jobs:
           python3 -m cyclonedx_py environment -v --pyproject pyproject.toml --mc-type library --output-reproducible --output-format json --outfile /tmp/sbom/sbom/dkb-robo/dkb-robo_sbom.json /tmp/dkbroboenv
 
       - name: "[ BUILD ] Upload SBOM"
-        # if: steps.dkb_robo_ver.outputs.tag != env.TAG_NAME
         run: |
           cd /tmp/sbom
           git config --global user.email "grindelsack@gmail.com"


### PR DESCRIPTION
I'd highly recommend [transitioning to a trusted publishing workflow](https://docs.pypi.org/trusted-publishers/using-a-publisher/). That uses only transient and tightly-scoped tokens, allowing you to get rid of `secrets.PYPI_TOKEN` and revoke. (I think it's currently very unlikely to be compromised, but new exploits are constantly discovered, and you're safer without `PYPI_TOKEN`.)

This PR doesn't set up trusted publishing, but does some cleanup of the workflow in order to prepare it. I'll make a second PR for that.

---

There are two prerequisites for trusted publishing:

1. An environment configured in the GitHub Settings: 

Important: Unless you set up "Required reviewers" there is little security benefit. With required reviewers, you will have to explicitly indicate approval before the publishing workflow can run.

Important: You must click "Save protection rules" after setting up required reviewers. Otherwise when you leave the page your configuration will be silently lost. :roll_eyes:

![image](https://github.com/user-attachments/assets/e1d2eb6d-d970-4300-88fb-f9ccc40491b9)

2. Link the PyPI repo with the GitHub environment you just created:

Open PyPI, select dkb-robo, select "Publishing", and add a new GitHub publisher with:
* Owner `grindsa`
* Repository name `dkb-robo`
* Workflow name `create_release.yml` (not `.github/workflows/create_release.yml`)
* Environment name, matching the name of the GitHub environment, e.g. `pypi` or `release`.

![image](https://github.com/user-attachments/assets/a797d6c7-7bf1-4c9e-8ae5-24ba47695c0e)

---

The major change in this PR is to isolate the upload to a separate job. This way, once we transition to trusted publishing, *only* that job needs to run within the publishing environment.