### PR TITLE
add command to download archived files

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Commands:
   accounts
   credit-limits
   download
+  download-archive
   scan-postbox
   last-login
   standing-orders

--- a/dkb_robo/cli.py
+++ b/dkb_robo/cli.py
@@ -440,6 +440,33 @@ def download(
     except dkb_robo.DKBRoboError as _err:
         click.echo(_err.args[0], err=True)
 
+@main.command()
+@click.pass_context
+@click.option(
+    "--path",
+    "-p",
+    type=click.Path(writable=True, path_type=pathlib.Path),
+    help="Path to save the documents to",
+    envvar="DKB_DOC_PATH",
+)
+@click.option(
+    "--prepend-date",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Prepend date to filename",
+    envvar="DKB_PREPEND_DATE",
+)
+def download_archive(ctx, path, prepend_date):
+    """download all archived documents from postbox"""
+    if not path:
+        path = Path("documents")
+    try:
+        with _login(ctx) as dkb:
+            dkb.download_archive(path=path, prepend_date=prepend_date)
+    except dkb_robo.DKBRoboError as _err:
+        click.echo(_err.args[0], err=True)
+
 
 class DataclassJSONEncoder(json.JSONEncoder):
     def default(self, obj):

--- a/dkb_robo/dkb_robo.py
+++ b/dkb_robo/dkb_robo.py
@@ -178,7 +178,7 @@ class DKBRobo(object):
     def scan_postbox(
         self, path=None, download_all=False, _archive=False, prepend_date=False
     ):
-        """scan posbox and return document dictionary"""
+        """scan postbox and return document dictionary"""
         self.logger.debug("DKBRobo.scan_postbox()\n")
         return self.download(
             Path(path) if path is not None else None, download_all, prepend_date
@@ -297,3 +297,16 @@ class DKBRobo(object):
             )
 
         return documents
+
+    def download_archive(
+        self,
+        path: Path,
+        prepend_date: bool = False
+    ):
+        """download postbox archive"""
+        postbox = PostBox(client=self.wrapper.client)
+        files = postbox.fetch_archived()
+        for file in files:
+            file.download(self.wrapper.client, path, prepend_date)
+
+        return files

--- a/dkb_robo/postbox.py
+++ b/dkb_robo/postbox.py
@@ -220,6 +220,47 @@ class PostboxItem:
         logger.debug("PostboxItem.date() for document %s ended with %s", self.id, date)
         return date.strftime("%Y-%m-%d")
 
+@filter_unexpected_fields
+@dataclass
+class PostboxLegacyFile:
+    id: str
+    subject: str
+    fileName: str
+    creationDate: str
+    path: Optional[Path] = None
+
+    def download(
+        self, client: requests.Session, target_path: Path, prepend_date: bool = False, overwrite: bool = False
+    ):
+        date = datetime.date.fromisoformat(self.creationDate.split("T")[0])
+
+        fileName = f"{date.strftime('%Y-%m-%d')}_{self.fileName}" if prepend_date else self.fileName
+
+        if self.path:
+            target_file = target_path / "Archiv" / self.path / fileName
+        else:
+            target_file = target_path / "Archiv" / fileName
+
+        logger.debug("PostboxLegacyFile.download(): %s to %s", self.id, target_file)
+
+        if not target_file.exists() or overwrite:
+            response = client.get(PostBox.BASE_URL + "/legacy-documents/" + self.id)
+            response.raise_for_status()
+            fileData = response.json()
+
+            if fileData["data"]["attributes"]["contentType"] == "application/pdf":
+                # decrypt base64 content
+                import base64
+                file_content = base64.b64decode(fileData["data"]["attributes"]["content"])
+
+                # create directories if necessary
+                target_file.parent.mkdir(parents=True, exist_ok=True)
+
+                with target_file.open("wb") as file:
+                    file.write(file_content)
+
+            return response.status_code
+        return False
 
 class PostBox:
     """Class for handling the DKB postbox."""
@@ -230,13 +271,14 @@ class PostBox:
     def __init__(self, client: requests.Session):
         self.client = client
 
+    @staticmethod
+    def __fix_link_url(url: str) -> str:
+        # print(f'old: {url}')
+        return url.replace("https://api.dkb.de/documentstorage/", PostBox.BASE_URL)
+
     def fetch_items(self) -> Dict[str, PostboxItem]:
         """Fetches all items from the postbox and merges document and message data."""
         logger.debug("PostBox.fetch_items(): Fetching messages")
-
-        def __fix_link_url(url: str) -> str:
-            # print(f'old: {url}')
-            return url.replace("https://api.dkb.de/documentstorage/", PostBox.BASE_URL)
 
         response = self.client.get(PostBox.BASE_URL + "/messages")
         response.raise_for_status()
@@ -254,7 +296,7 @@ class PostBox:
                     id=doc["id"],
                     document=Document(
                         **doc.get("attributes", {}),
-                        link=__fix_link_url(doc["links"]["self"]),
+                        link=self.__fix_link_url(doc["links"]["self"]),
                     ),
                     message=None,
                 )
@@ -267,8 +309,45 @@ class PostBox:
                 if msg_id in items:
                     items[msg_id].message = Message(
                         **msg.get("attributes", {}),
-                        link=__fix_link_url(msg["links"]["self"]),
+                        link=self.__fix_link_url(msg["links"]["self"]),
                     )
-
             return items
         raise DKBRoboError("Could not fetch messages/documents.")
+
+    def fetch_archived(self) -> Dict[str, PostboxLegacyFile]:
+        """Fetches all items from the postbox archive."""
+        logger.debug("PostBox.fetch_archived(): Fetching folders")
+
+        base_url = PostBox.BASE_URL + "folders"
+
+        response = self.client.get(base_url)
+        response.raise_for_status()
+        folders = response.json()
+
+        files = []
+
+        if folders:
+
+            def __process_folder(folder, parent_path):
+                if folder.get("attributes"):
+                    folder_name = folder["attributes"]["name"]
+                else:
+                    folder_name = folder["name"]
+
+                response = self.client.get(base_url + "/" + folder["id"])
+                response.raise_for_status()
+                folder_contents = response.json()
+                path = parent_path / folder_name
+
+                for file in folder_contents["data"]["attributes"]["files"]:
+                    files.append(PostboxLegacyFile(**{**file, "path": path}))
+
+                for subfolder in folder_contents["data"]["attributes"]["subfolders"]:
+                    __process_folder(subfolder, path)
+
+            for folder in folders["data"]:
+                __process_folder(folder, Path(""))
+
+            return files
+        else:
+            raise DKBRoboError("Could not fetch archived files.")


### PR DESCRIPTION
I've tried my luck to add a command that downloads files from the postbox archive, including the "old" archive.

It iterates through subfolders and downloads all files to the path provided. It is not possible to choose certain files as it is meant to be run only once to get a local copy of the online archive.

I've not programmed much in python. My approach works fine for me, though.

This should fix issue #59.